### PR TITLE
Fixes #89

### DIFF
--- a/css/tabular-pages.css
+++ b/css/tabular-pages.css
@@ -136,8 +136,9 @@ table.data-table td{
   border:0;
   border-left: 1px solid #efefef;
   border-bottom: 1px solid #efefef;
-  /*padding: 12px 5px;
-  margin-bottom: 4px;*/
+  /*padding: 12px 5px;*/
+  min-width: 60px;
+  /*margin-bottom: 4px;*/
 }
 table.data-table td:first-child{
   border-left:0;

--- a/post-types/templates/single-tabular.php
+++ b/post-types/templates/single-tabular.php
@@ -358,7 +358,6 @@ jQuery(document).ready(function($) {
     lengthMenu: [[10, 25, 50, -1], [10, 25, 50, "All"]],
     order: [[ <?php echo isset($group_data_by_column_index) && $group_data_by_column_index != '' ?  $group_data_by_column_index : 0 ?>, 'asc' ]],
     displayLength: 50,
-    "aoColumns": [{ "sWidth": "40%" }, { "sWidth": "20%" }, { "sWidth": "14%" }, { "sWidth": "12%" }, { "sWidth": "17%" }],
 		<?php if (odm_language_manager()->get_current_language() == 'km'): ?>
 		"oLanguage": {
 				"sLengthMenu": 'បង្ហាញចំនួន <select>'+


### PR DESCRIPTION
@Huyeng @prustar The problem with Issue #89 is that the width of the columns (in %) was hard-coded  considering the table to contain ALWAYS 4 columns. If editors remove one of the columns by changing the config, then a javascript error was thrown because the table expects to have 4 columns.

![screenshot from 2017-01-02 10-29-35](https://cloud.githubusercontent.com/assets/384894/21586913/6f4facb4-d0d6-11e6-9727-531105f692cc.png)

This PR removes that line of code that determines the width of the columns (in %) and solves the problem with the consequence that column width is then adjusted to fit its contents dynamically. Looks like below:

![screenshot from 2017-01-02 10-32-00](https://cloud.githubusercontent.com/assets/384894/21586932/b5ecddcc-d0d6-11e6-8d1b-943781d45c5c.png)

@Huyeng @prustar would you agree on leaving the column width as pictured above?